### PR TITLE
Fix for array_values() expects parameter 1 to be array

### DIFF
--- a/src/GlobalScope.php
+++ b/src/GlobalScope.php
@@ -28,6 +28,10 @@ abstract class GlobalScope implements ScopeInterface
     {
         $query = $builder->getQuery();
 
+        if (is_null($query->wheres)) {
+            return;
+        }
+
         $bindingKey = 0;
 
         $scopeConstraints = $this->getScopeConstraints($model);


### PR DESCRIPTION
Thank you @sebastiaanluca for pointing out that $query->wheres can be null https://github.com/jarektkaczyk/laravel-global-scope/issues/5
